### PR TITLE
Add --no-tty option; provide default for EDITOR env var

### DIFF
--- a/creds
+++ b/creds
@@ -121,7 +121,7 @@ cmd_set() {
   credfile=$(check_credfile "$cred_name")
   [ -z "$credfile" ] && die
 
-  $GPG_BIN -d --quiet < "$credfile" | while read -r line ; do
+  $GPG_BIN -d --no-tty --quiet < "$credfile" | while read -r line ; do
     if [[ "$line" =~ ^[^[:space:]]+= ]]; then
       echo "export $line"
     fi
@@ -135,7 +135,7 @@ cmd_unset() {
   credfile=$(check_credfile "$cred_name")
   [ -z "$credfile" ] && die
 
-  $GPG_BIN -d --quiet < "$credfile" | while read -r line ; do
+  $GPG_BIN -d --no-tty --quiet < "$credfile" | while read -r line ; do
     if [[ "$line" =~ ^[^[:space:]]+= ]]; then
       env_var=$(awk -F= '{print $1}' <<<"$line")
       echo "unset $env_var"
@@ -150,7 +150,7 @@ cmd_edit() {
   credfile="$CREDS_DIR/$cred_name.gpg"
   tmpfile=$(mktemp "tmp-$cred_name.XXXXXXXX") || die
   if [ -f "$credfile" ]; then
-    $GPG_BIN -d --quiet < "$credfile"  >"$tmpfile"
+    $GPG_BIN -d --no-tty --quiet < "$credfile"  >"$tmpfile"
   else
     echo "Unable to find '$credfile'. Creating new file."
   fi

--- a/creds
+++ b/creds
@@ -156,7 +156,7 @@ cmd_edit() {
   fi
 
   orig_cksum=$(cksum "$tmpfile")
-  $EDITOR "$tmpfile"
+  ${EDITOR:-vi} "$tmpfile"
   new_cksum=$(cksum "$tmpfile")
   if [ "$orig_cksum" != "$new_cksum" ]; then
     echo "Encrypting..."


### PR DESCRIPTION
The gpg2 binary I have installed from GPGTools still spits out extra output even with --quiet. I found adding --no-tty fixed it.

Also, I don't usually have EDITOR set for some reason, so I added a default of "vi".
